### PR TITLE
Make the sample build in VS 2019 out of the box

### DIFF
--- a/Samples/2.3/HelloWorldCpp/src/OrleansClientCpp/OrleansClientCpp.vcxproj
+++ b/Samples/2.3/HelloWorldCpp/src/OrleansClientCpp/OrleansClientCpp.vcxproj
@@ -29,7 +29,7 @@
     <ProjectGuid>{6E611DF6-162A-4EE5-A18D-8E7F02861819}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>OrleansClientCpp</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -48,7 +48,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">


### PR DESCRIPTION
I wasn't able to build the sample until I made these changes. Do you see any problem with them?

Switch WindowsTargetPlatformVersion to  "10.0".
Switch to VS 2019 toolset.